### PR TITLE
Update branding to DealBrief

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "MeetingBrief",
+  title: "DealBrief",
   description: "Instant intel for every meeting.",
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -225,7 +225,7 @@ export default function Page() {
       <nav className="sticky top-0 z-50 backdrop-blur bg-white/80 border-b border-slate-200">
         <div className="max-w-6xl mx-auto flex items-center justify-between px-4 py-3">
           <Link href="/" className="font-semibold text-xl">
-            MeetingBrief
+            DealBrief
           </Link>
 
           <div className="hidden md:flex gap-6 items-center">
@@ -443,7 +443,7 @@ export default function Page() {
       {/* FOOTER ------------------------------------------------------------- */}
       <footer className="bg-white border-t border-slate-200">
         <div className="max-w-6xl mx-auto px-4 py-10 flex flex-col sm:flex-row justify-between text-sm text-slate-500">
-          <p>© {new Date().getFullYear()} MeetingBrief</p>
+          <p>© {new Date().getFullYear()} DealBrief</p>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- rename site metadata title to DealBrief
- update navbar and footer references

## Testing
- `npm run lint` *(fails: `next` not found)*