### PR TITLE
Change heading to Deal Brief

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,7 @@ const supabase: SupabaseClient = createClient(supabaseUrl, supabaseAnon);
 /* -------------------------------------------------------------------------- */
 const sampleBriefHtmlContent = `
 <div>
-  <h2><strong>Meeting Brief: Jensen Huang – NVIDIA</strong></h2>
+  <h2><strong>Deal Brief: Jensen Huang – NVIDIA</strong></h2>
   <p>&nbsp;</p>
   <h3><strong>Executive Summary</strong></h3>
   <p>

--- a/src/lib/MeetingBriefGeminiPipeline.ts
+++ b/src/lib/MeetingBriefGeminiPipeline.ts
@@ -161,9 +161,9 @@
      jobs: string[],
    ): string => {
      const s = "<p>&nbsp;</p>";
-     return `
-   <div>
-     <h2><strong>Meeting Brief: ${name} – ${org}</strong></h2>
+    return `
+  <div>
+    <h2><strong>Deal Brief: ${name} – ${org}</strong></h2>
    ${s}<h3><strong>Executive Summary</strong></h3>
    ${pSent(json.executive, cites)}
    ${s}<h3><strong>Job History</strong></h3>


### PR DESCRIPTION
## Summary
- tweak sample brief heading wording in the page example
- switch meeting heading in Gemini pipeline to "Deal Brief"

## Testing
- `npm run lint` *(fails: `next` not found)*