### PR TITLE
Rename meeting brief pipeline

### DIFF
--- a/src/app/api/meetingbrief/route.ts
+++ b/src/app/api/meetingbrief/route.ts
@@ -4,7 +4,7 @@
  * -----------------------------------------------------------------*/
 
 import { NextRequest, NextResponse } from "next/server";
-import { buildMeetingBriefGemini } from "@/lib/MeetingBriefGeminiPipeline";
+import { buildDealBriefGemini } from "@/lib/DealBriefGeminiPipeline";
 
 /*──────────────────────────  superscript helper  */
 
@@ -57,7 +57,7 @@ export async function POST(req: NextRequest) {
     }
 
     // call the briefing pipeline (team will be derived from LinkedIn later)
-    const payload = await buildMeetingBriefGemini(name, organization);
+  const payload = await buildDealBriefGemini(name, organization);
 
     if (payload.brief && payload.citations?.length) {
       payload.brief = normalizeCitations(payload.brief, payload.citations);

--- a/src/lib/DealBriefGeminiPipeline.ts
+++ b/src/lib/DealBriefGeminiPipeline.ts
@@ -1,5 +1,5 @@
 /* ──────────────────────────────────────────────────────────────────────────
-   src/lib/MeetingBriefGeminiPipeline.ts
+   src/lib/DealBriefGeminiPipeline.ts
    --------------------------------------------------------------------------
    HARD CONTRACT
    ─ model returns only:
@@ -68,7 +68,7 @@
      title: string;
      snippet: string;
    }
-   export interface MeetingBriefPayload {
+export interface DealBriefPayload {
      brief: string;
      citations: Citation[];
      tokens: number;
@@ -176,10 +176,10 @@
    };
    
    /* ── MAIN ----------------------------------------------------------------- */
-   export async function buildMeetingBriefGemini(
-     name: string,
-     org: string,
-   ): Promise<MeetingBriefPayload> {
+export async function buildDealBriefGemini(
+  name: string,
+  org: string,
+): Promise<DealBriefPayload> {
      let serperCalls = 0;
      const serpResults: SerpResult[] = [];
    


### PR DESCRIPTION
## Summary
- rename `src/lib/MeetingBriefGeminiPipeline.ts` to `src/lib/DealBriefGeminiPipeline.ts`
- update exported interface to `DealBriefPayload`
- rename builder function to `buildDealBriefGemini`
- adjust import path and usage in `meetingbrief` API route

## Testing
- `npm run lint` *(fails: `next` not found)*