### PR TITLE
Replace MeetingBrief with DealBrief

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "meetingbrief",
+  "name": "dealbrief",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/api/dealbrief/route.ts
+++ b/src/app/api/dealbrief/route.ts
@@ -1,10 +1,10 @@
 /* ------------------------------------------------------------------
- *  API route:  POST /api/meetingbrief
+ *  API route:  POST /api/dealbrief
  *  Body JSON:  { "name": "<person>", "organization": "<company>" }
  * -----------------------------------------------------------------*/
 
 import { NextRequest, NextResponse } from "next/server";
-import { buildMeetingBriefGemini } from "@/lib/MeetingBriefGeminiPipeline";
+import { buildDealBriefGemini } from "@/lib/DealBriefGeminiPipeline";
 
 /*──────────────────────────  superscript helper  */
 
@@ -57,7 +57,7 @@ export async function POST(req: NextRequest) {
     }
 
     // call the briefing pipeline (team will be derived from LinkedIn later)
-    const payload = await buildMeetingBriefGemini(name, organization);
+    const payload = await buildDealBriefGemini(name, organization);
 
     if (payload.brief && payload.citations?.length) {
       payload.brief = normalizeCitations(payload.brief, payload.citations);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "MeetingBrief",
+  title: "DealBrief",
   description: "Instant intel for every meeting.",
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -188,7 +188,7 @@ export default function Page() {
     void logSearchEvent(form.name.trim(), form.organization.trim());
 
     try {
-      const res = await fetch("/api/meetingbrief", {
+      const res = await fetch("/api/dealbrief", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(form),
@@ -225,7 +225,7 @@ export default function Page() {
       <nav className="sticky top-0 z-50 backdrop-blur bg-white/80 border-b border-slate-200">
         <div className="max-w-6xl mx-auto flex items-center justify-between px-4 py-3">
           <Link href="/" className="font-semibold text-xl">
-            MeetingBrief
+            DealBrief
           </Link>
 
           <div className="hidden md:flex gap-6 items-center">
@@ -443,7 +443,7 @@ export default function Page() {
       {/* FOOTER ------------------------------------------------------------- */}
       <footer className="bg-white border-t border-slate-200">
         <div className="max-w-6xl mx-auto px-4 py-10 flex flex-col sm:flex-row justify-between text-sm text-slate-500">
-          <p>© {new Date().getFullYear()} MeetingBrief</p>
+          <p>© {new Date().getFullYear()} DealBrief</p>
         </div>
       </footer>
     </div>

--- a/src/lib/DealBriefGeminiPipeline.ts
+++ b/src/lib/DealBriefGeminiPipeline.ts
@@ -1,5 +1,5 @@
 /* ──────────────────────────────────────────────────────────────────────────
-   src/lib/MeetingBriefGeminiPipeline.ts
+   src/lib/DealBriefGeminiPipeline.ts
    --------------------------------------------------------------------------
    HARD CONTRACT
    ─ model returns only:
@@ -68,7 +68,7 @@
      title: string;
      snippet: string;
    }
-   export interface MeetingBriefPayload {
+   export interface DealBriefPayload {
      brief: string;
      citations: Citation[];
      tokens: number;
@@ -176,10 +176,10 @@
    };
    
    /* ── MAIN ----------------------------------------------------------------- */
-   export async function buildMeetingBriefGemini(
+   export async function buildDealBriefGemini(
      name: string,
      org: string,
-   ): Promise<MeetingBriefPayload> {
+   ): Promise<DealBriefPayload> {
      let serperCalls = 0;
      const serpResults: SerpResult[] = [];
    


### PR DESCRIPTION
## Summary
- rename occurrences of `MeetingBrief` to `DealBrief`
- rename MeetingBriefGeminiPipeline to DealBriefGeminiPipeline
- rename API endpoint to `/api/dealbrief`
- update package name

## Testing
- `npm run lint` *(fails: `next` not found)*